### PR TITLE
Fix: Use correct latent channels in Story2BoardPipeline

### DIFF
--- a/story2board_pipeline.py
+++ b/story2board_pipeline.py
@@ -72,7 +72,7 @@ class Story2BoardPipeline(FluxPipeline):
 
         latents = self.prepare_latents(
             batch_size * num_images_per_prompt,
-            self.transformer.config.in_channels,
+            self.vae.config.latent_channels,
             height,
             width,
             final_prompt_embeds.dtype,


### PR DESCRIPTION
The `prepare_latents` function was being called with `self.transformer.config.in_channels` instead of `self.vae.config.latent_channels`. This caused a shape mismatch error in the transformer.

This change corrects the `prepare_latents` call to use the VAE's latent channels, which is the standard implementation in the base `FluxPipeline`.