### PR TITLE
Fix: Correct transformer arguments in Story2BoardPipeline

### DIFF
--- a/story2board_pipeline.py
+++ b/story2board_pipeline.py
@@ -67,15 +67,13 @@ class Story2BoardPipeline(FluxPipeline):
             prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds])
             pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds])
         
-        pooled_prompt_embeds = pooled_prompt_embeds.unsqueeze(1).expand(-1, prompt_embeds.shape[1], -1)
-        final_prompt_embeds = torch.cat([pooled_prompt_embeds, prompt_embeds], dim=-1)
 
         latents = self.prepare_latents(
             batch_size * num_images_per_prompt,
             self.vae.config.latent_channels,
             height,
             width,
-            final_prompt_embeds.dtype,
+            prompt_embeds.dtype,
             device,
             generator,
             latents,
@@ -97,7 +95,10 @@ class Story2BoardPipeline(FluxPipeline):
                     )
                 ):
                     noise_pred = self.transformer(
-                        latent_model_input, timestep=t, encoder_hidden_states=final_prompt_embeds
+                        latent_model_input,
+                        timestep=t,
+                        encoder_hidden_states=prompt_embeds,
+                        pooled_projections=pooled_prompt_embeds,
                     ).sample
 
                 if do_classifier_free_guidance:


### PR DESCRIPTION
The custom pipeline was incorrectly combining prompt embeddings and failing to pass the `pooled_projections` to the transformer, which caused a TypeError.

This change removes the custom embedding logic and updates the transformer call to pass `prompt_embeds` and `pooled_prompt_embeds` as separate arguments, aligning the implementation with the base `FluxPipeline`.